### PR TITLE
Reusable GHA workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,13 +1,30 @@
-name: Build & Upload artifact
+name: Build & Upload
 
 on:
-  push:
-    branches: [ main, internationalization ]
   workflow_dispatch:
-
-concurrency:
-  group: build-${{ github.ref }}
-  cancel-in-progress: true    
+    inputs:
+      node-version:
+        description: 'Node.js version to use for the build'
+        type: number
+        required: false
+        default: 22.11.0
+      working-dir:
+        description: 'Directory where the Astro project is located'
+        type: string
+        required: false
+        default: './website'
+  workflow_call:
+    inputs:
+      node-version:
+        description: 'Node.js version to use for the build'
+        type: number
+        required: false
+        default: 22.11.0
+      working-dir:
+        description: 'Directory where the Astro project is located'
+        type: string
+        required: false
+        default: './website'
 
 jobs:
   build:
@@ -15,12 +32,11 @@ jobs:
     environment: deploy
     defaults:
       run:
-        working-directory: ./website
+        working-directory: ${{ inputs.working-dir }}
     services:
       libretranslate:
         image: libretranslate/libretranslate:latest
-        ports:
-          - 5000:5000
+        ports: ['5000:5000']
         options: --env LT_LOAD_ONLY=en,pt,pt-br,de,fr,es,it
     timeout-minutes: 20
     outputs:
@@ -29,30 +45,30 @@ jobs:
       artifact-digest: ${{ steps.upload.outputs.artifact-digest }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v4 # Checkout the repository to the runner
+    # - uses: actions/cache@v4
+    #   with:
+    #     path: ~/.npm
+    #     key: ${{ runner.os }}-node-${{ hashFiles('${{ inputs.working-dir }}/package-lock.json') }}
+    #     restore-keys: |
+    #       ${{ runner.os }}-node-
 
-    - name: Setup Node.js
+    - name: Set up Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: 22.11.0
+        node-version: ${{ inputs.node-version }}
+        cache: 'npm'
+        cache-dependency-path: ${{ inputs.working-dir }}/package-lock.json
 
-    - name: Cache node modules
-      uses: actions/cache@v4
-      with:
-        path: ~/.npm
-        key: ${{ runner.os }}-node-${{ hashFiles('website/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-node-
-
-    - name: Install dependencies
+    - name: Install dependencies with NPM
       run: npm ci
-
-    - name: Wait for LibreTranslate
+    
+    - name: Wait for LibreTranslate # Wait for the LibreTranslate service to be ready
       run: |
-        timeout 60 bash -c \
-          'until curl --silent --output /dev/null --write-out "%{http_code}" http://localhost:5000/; do sleep 2; done'
+        timeout 60 bash -c 'until curl --silent --output /dev/null --write-out "%{http_code}" http://localhost:5000/; do sleep 2; done'
 
-    - name: Build Astro site
+    - name: Build with Astro
+      run: npm run build
       env:
         LIBRETRANSLATE: http://localhost:5000/
         PUBLIC_BASE_URL: ${{ vars.PUBLIC_BASE_URL }}
@@ -61,32 +77,11 @@ jobs:
         SPOTIFY_CLIENT_ID: ${{ secrets.SPOTIFY_CLIENT_ID }}
         SPOTIFY_CLIENT_SECRET: ${{ secrets.SPOTIFY_CLIENT_SECRET }}
         GOOGLE_ANALYTICS_ID: ${{ secrets.GOOGLE_ANALYTICS_ID }}
-      run: npm run build
 
     - name: Upload artifact
       id: upload
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ vars.ARTIFACT_NAME || 'site-dist' }}
-        path: ./website/dist
+        name: ${{ vars.ARTIFACT_NAME }}
+        path: ./dist
         retention-days: 90
-
-  notify:
-    needs: build
-    runs-on: ubuntu-latest
-    environment: discord
-    if: ${{ needs.build.result == 'success' }}
-
-    steps:
-      - name: Send Discord notification
-        uses: stegzilla/discord-notify@v4
-        with:
-          webhook_url: ${{ secrets.BUILD }}
-          username: "GHA build-artifact"
-          title: "Build & Upload Artifact Success"
-          message: |
-            ✅ Build and artifact upload succeeded for **${{ github.repository }}**
-            GHA run: #${{ github.run_number }}
-            Artifact ID: ${{ needs.build.outputs.artifact-id }}
-            Artifact URL: ${{ needs.build.outputs.artifact-url }}
-            Artifact SHA: ${{ needs.build.outputs.artifact-digest }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Main CI
 
 on:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
       - main
       - internationalization
   workflow_dispatch:
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,87 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - internationalization
+  workflow_dispatch:
+
+jobs:
+  build:
+    uses: ./.github/workflows/build.yml
+
+  clear-artifacts:
+    needs: build
+    uses: ./.github/workflows/clear-artifacts.yml
+
+  trigger-render:
+    needs: build
+    uses: ./.github/workflows/trigger-render.yml
+
+  deploy-pages:
+    needs: build
+    uses: ./.github/workflows/deploy-pages.yml
+
+  notify-build:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: discord
+    steps:
+    - uses: stegzilla/discord-notify@v4
+      with:
+        webhook_url: ${{ secrets.BUILD }}
+        username: "GHA build-artifact"
+        title: "Build & Upload Artifact Success"
+        message: |
+          ✅ Build and artifact upload succeeded for **${{ github.repository }}**
+          GHA run: #${{ github.run_number }}
+          Artifact ID: ${{ needs.build.outputs.artifact-id }}
+          Artifact URL: ${{ needs.build.outputs.artifact-url }}
+          Artifact SHA: ${{ needs.build.outputs.artifact-digest }}
+
+  notify-clear:
+    needs: clear-artifacts
+    runs-on: ubuntu-latest
+    environment: discord
+    steps:
+    - uses: stegzilla/discord-notify@v4
+      with:
+        webhook_url: ${{ secrets.CLEAR_ARTIFACTS }}
+        title: "GHA Clear Old Artifacts"
+        username: "GHA clear-artifacts"
+        message: |
+          ✅ Old artifacts cleared successfully.
+          ${{ needs.clear-artifacts.outputs.result }}
+
+  notify-render:
+    needs: trigger-render
+    runs-on: ubuntu-latest
+    environment: discord
+    steps:
+    - uses: stegzilla/discord-notify@v4
+      with:
+        webhook_url: ${{ secrets.DEPLOY_RENDER }}
+        title: "Render Deploy Triggered with API"
+        username: "GHA trigger-render"
+        message: |
+          🚀 Render deploy triggered successfully for **${{ github.repository }}**  
+          • Commit: `${{ github.sha }}`  
+          • Run: #${{ github.run_number }}
+
+  notify-pages:
+    needs: deploy-pages
+    runs-on: ubuntu-latest
+    environment: discord
+    steps:
+    - uses: stegzilla/discord-notify@v4
+      with:
+        webhook_url: ${{ secrets.DEPLOY_PAGES }}
+        username: "GHA deploy-pages"
+        title: "Deploy Pages Success"
+        message: |
+          ✅ Deploy to Github Pages succeeded for **${{ github.repository }}**
+          - GHA run: #${{ github.run_number }}
+          - Artifact Name: `${{ needs.deploy-pages.outputs.artifact-name }}`
+          - Download Path: `${{ needs.deploy-pages.outputs.download-path }}`
+          - **Pages URL: `${{ needs.deploy-pages.outputs.pages-url }}`**

--- a/.github/workflows/clear-artifacts.yml
+++ b/.github/workflows/clear-artifacts.yml
@@ -2,9 +2,7 @@ name: Clear old artifacts
 
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows: ["Build & Upload artifact"]
-    types: [completed]
+  workflow_call:
 
 jobs:
   cleanup:
@@ -21,7 +19,7 @@ jobs:
           script: |
             const perPage = parseInt(process.env.PER_PAGE) || 100; // Default 100
             const keepCount = parseInt(process.env.LAST_ARTIFACTS) || 10; // Default 10
-            const prefix = `${process.env.ARTIFACT_PREFIX}` || "site-dist";
+            const prefix = `${process.env.ARTIFACT_PREFIX}`;
 
             // * Get the 100 latest artifacts in https://github.com/AdrianoLMRS/AndreValerio
             const res = await github.rest.actions.listArtifactsForRepo({
@@ -47,21 +45,4 @@ jobs:
         env:
           PER_PAGE: ${{ vars.PER_PAGE }}
           LAST_ARTIFACTS: ${{ vars.LAST_ARTIFACTS }}
-          ARTIFACT_PREFIX: ${{ vars.PREFIX }}
-
-  notify:
-    needs: cleanup
-    runs-on: ubuntu-latest
-    environment: discord
-    if: ${{ needs.cleanup.result == 'success' }}
-
-    steps:
-      - name: Send Discord notification
-        uses: stegzilla/discord-notify@v4
-        with:
-          webhook_url: ${{ secrets.CLEAR_ARTIFACTS }}
-          title: "GHA Clear Old Artifacts"
-          username: "GHA clear-artifacts"
-          message: |
-            ✅ Old artifacts cleared successfully.
-            ${{ needs.cleanup.outputs.result }}
+          ARTIFACT_PREFIX: ${{ vars.PREFIX }} # TODO : change environment scope in Github

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -2,15 +2,12 @@ name: Deploy Pages
 
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows: ["Build & Upload artifact"]
-    types: [completed]
+  workflow_call:
 
 jobs:
   deploy-pages:
-    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
-    environment: deploy
     runs-on: ubuntu-latest
+    environment: deploy
     outputs:
       artifact-name: ${{ vars.ARTIFACT_NAME }}
       download-path: ${{ steps.download-artifact.outputs.download-path }}
@@ -24,7 +21,7 @@ jobs:
       id: download-artifact
       with:
         name: ${{ vars.ARTIFACT_NAME }}
-        path: ./${{ vars.ARTIFACT_NAME }}}}
+        path: ./${{ vars.ARTIFACT_NAME }}
 
     - run: echo "Artifact downloaded path - ${{ steps.download-artifact.outputs.download-path }}"
 
@@ -47,23 +44,3 @@ jobs:
         artifact_name: ${{ vars.ARTIFACT_NAME }}
 
     - run: echo "Pages URL - ${{ steps.deploy-pages.outputs.page_url }}"
-
-  notify:
-    needs: deploy-pages
-    runs-on: ubuntu-latest
-    environment: discord
-    if: ${{ needs.deploy-pages.result == 'success' }}
-
-    steps:
-      - name: Send Discord notification
-        uses: stegzilla/discord-notify@v4
-        with:
-          webhook_url: ${{ secrets.DEPLOY_PAGES }}
-          username: "GHA deploy-pages"
-          title: "Deploy Pages Success"
-          message: |
-            ✅ Deploy to Github Pages succeeded for **${{ github.repository }}**
-            - GHA run: #${{ github.run_number }}
-            - Artifact Name: `${{ needs.deploy-pages.outputs.artifact-name }}`
-            - Download Path: `${{ needs.deploy-pages.outputs.download-path }}`
-            - **Pages URL: `${{ needs.deploy-pages.outputs.pages-url }}`**

--- a/.github/workflows/trigger-render.yml
+++ b/.github/workflows/trigger-render.yml
@@ -2,40 +2,17 @@ name: Trigger Render Deploy
 
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows: ["Build & Upload artifact"]
-    types: [completed]
+  workflow_call:
 
 jobs:
   trigger-render-deploy:
-    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     environment: deploy
-
     steps:
-      - name: Trigger Render Deploy (API)
-        run: |
-          curl --request POST \
-              --url https://api.render.com/v1/services/${{ secrets.RENDER_SERVICE_ID }}/deploys \
-              --header 'accept: application/json' \
-              --header 'authorization: Bearer ${{ secrets.RENDER_API_KEY }}' \
-              --header 'content-type: application/json' \
-              --data '{"clearCache":"clear", "commitId": "${{ github.sha }}"}'
-
-  notify:
-    needs: trigger-render-deploy
-    runs-on: ubuntu-latest
-    environment: discord
-    if: ${{ needs.trigger-render-deploy.result == 'success' }}
-
-    steps:
-      - name: Send Discord notification
-        uses: stegzilla/discord-notify@v4
-        with:
-          webhook_url: ${{ secrets.DEPLOY_RENDER}}
-          title: "Render Deploy Triggered with API"
-          username: "GHA trigger-render"
-          message: |
-            🚀 Render deploy triggered successfully for **${{ github.repository }}**  
-            • Commit: `${{ github.sha }}`  
-            • Run: #${{ github.run_number }}
+    - run: |
+        curl -X POST \
+          https://api.render.com/v1/services/${{ secrets.RENDER_SERVICE_ID }}/deploys \
+          -H "accept: application/json" \
+          -H "authorization: Bearer ${{ secrets.RENDER_API_KEY }}" \
+          -H "content-type: application/json" \
+          -d '{"clearCache":"clear","commitId":"'"${{ github.sha }}"'"}'


### PR DESCRIPTION
Reusing GHA workflows for only one CI file ([`ci.yml`][ci-file]), this is better for sharing files/artifacts between workflows and is better for control.

[ci-file]: https://github.com/AdrianoLMRS/AndreValerio/commit/375f644c28d908f1c46056a683213b041b8676b3#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f